### PR TITLE
rewrite/iterate to simplify MediaViewer a bit

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,9 +8,6 @@ Migrating to Github Issues now that that has improved quite a bit since this was
 - get rid of YouTube lib currently used for something lighter/hooks-friendly for `MediaViewer`.
 - use grid layout for ultrawide monitors like mine at home which cannot in any way use pixel-grid-snapping/zoom to look less awkward.
 
-## CV
-- use better library for rendering (separate from generation) now that resume creation is 100% code-generated.
-
 ## Misc
 - auto-generate sitemap.xml using react-router library.
 - generate meta data for content on serverside (possibly integrated with point right above).

--- a/client/js/modules/projects/components/media-reel/MediaReel.js
+++ b/client/js/modules/projects/components/media-reel/MediaReel.js
@@ -180,7 +180,14 @@ export default function MediaReel({ media, width, maxWidth, aspectRatio, ...prop
     useEffect(() => { handleMediaChange(media) }, [media]);
 
     const [vpW, vpH] = useViewportSizes();
-    const classes = useStyles({ vpW, vpH, width, maxWidth, aspectRatio, ...props });
+    const classes = useStyles({
+        vpW,
+        vpH,
+        width,
+        maxWidth,
+        aspectRatio,
+        ...props
+    });
 
     return (
         <div className={ classes.container }>


### PR DESCRIPTION
Very old code (written pre-React functional components in 2017) so could an iteration. Also fixes issue with media loading introduced in recent change. There is one known UX issue of not pausing auto-play of MediaReel but just making some iterative progress -- not a lot of time between other projects.